### PR TITLE
add-use-app-outlet

### DIFF
--- a/src/app/layout/layout.tsx
+++ b/src/app/layout/layout.tsx
@@ -1,12 +1,14 @@
 import { Outlet } from 'react-router'
 import Header from '../../widgets/header/header'
 import Footer from '../../widgets/footer/footer'
-
+import ArticlesSkeleton from '../../shared/ui/articles-skeleton'
 const Layout = () => {
   return (
     <>
       <Header />
-      <Outlet />
+      <Outlet
+        context={{ renderArticlesSkeleton: () => <ArticlesSkeleton /> }}
+      />
       <Footer />
     </>
   )

--- a/src/pages/by-category/index.tsx
+++ b/src/pages/by-category/index.tsx
@@ -1,8 +1,8 @@
 import { useParams } from 'react-router'
 import TopHeadlines from '../../widgets/top-headlines'
 import { useGetNewsByCategoryQuery } from '../../shared/api/news-api'
-import Loader from '../../shared/ui/loader'
 import { useAppContext } from '../../shared/api/app-context-api/app-context-api'
+import useAppOutlet from '../../shared/hooks/use-app-outlet'
 import s from './config/main.module.css'
 
 const ByCategory = () => {
@@ -12,11 +12,12 @@ const ByCategory = () => {
     country,
     category,
   })
+  const { renderArticlesSkeleton } = useAppOutlet()
   const articles = isSuccess ? data.articles : []
 
   return (
     <div className={s.main}>
-      {isLoading ? <Loader /> : <TopHeadlines data={articles} />}
+      {isLoading ? renderArticlesSkeleton() : <TopHeadlines data={articles} />}
     </div>
   )
 }

--- a/src/pages/history-page/index.tsx
+++ b/src/pages/history-page/index.tsx
@@ -2,11 +2,13 @@ import { useState, useEffect } from 'react'
 import Loader from '../../shared/ui/loader'
 import TopHeadlines from '../../widgets/top-headlines'
 import { useAppContext } from '../../shared/api/app-context-api/app-context-api'
+import useAppOutlet from '../../shared/hooks/use-app-outlet'
 import s from './config/main.module.css'
 
 const HistoryPage = () => {
   const { history } = useAppContext()
   const [isLoading, setLoading] = useState(true)
+  const { renderArticlesSkeleton } = useAppOutlet()
   useEffect(() => {
     new Promise<boolean>((res) => setTimeout(() => res(false), 1000)).then(
       (d) => setLoading(d),
@@ -14,7 +16,7 @@ const HistoryPage = () => {
   }, [])
   return (
     <div className={s.main}>
-      {isLoading ? <Loader /> : <TopHeadlines data={history} />}
+      {isLoading ? renderArticlesSkeleton() : <TopHeadlines data={history} />}
     </div>
   )
 }

--- a/src/pages/main/main-page.tsx
+++ b/src/pages/main/main-page.tsx
@@ -1,16 +1,18 @@
 import { useAppContext } from '../../shared/api/app-context-api/app-context-api'
-import { useGetHeadlinesQuery } from '../../shared/api/news-api'
-import Loader from '../../shared/ui/loader'
 import TopHeadlines from '../../widgets/top-headlines'
+import { useGetHeadlinesQuery } from '../../shared/api/news-api'
+import useAppOutlet from '../../shared/hooks/use-app-outlet'
+import Loader from '../../shared/ui/loader'
 import s from './config/main.module.css'
 
 const MainPage = () => {
   const { country } = useAppContext()
   const { data, isLoading, isSuccess } = useGetHeadlinesQuery({ country })
+  const { renderArticlesSkeleton } = useAppOutlet()
   const articles = isSuccess ? data.articles : []
   return (
     <div className={s.main}>
-      {isLoading ? <Loader /> : <TopHeadlines data={articles} />}
+      {isLoading ? renderArticlesSkeleton() : <TopHeadlines data={articles} />}
     </div>
   )
 }

--- a/src/shared/hooks/use-app-outlet.ts
+++ b/src/shared/hooks/use-app-outlet.ts
@@ -1,0 +1,9 @@
+import { useOutletContext } from 'react-router'
+interface OutletContext {
+  renderArticlesSkeleton: () => JSX.Element
+}
+
+const useAppOutlet = () => {
+  return useOutletContext<OutletContext>()
+}
+export default useAppOutlet

--- a/src/shared/ui/articles-skeleton/index.tsx
+++ b/src/shared/ui/articles-skeleton/index.tsx
@@ -1,0 +1,33 @@
+import { Skeleton, Stack } from '@mui/material'
+
+const ArticleSkeleton = () => {
+  return (
+    <>
+      <Skeleton
+        sx={{ bgcolor: 'grey.150' }}
+        animation='wave'
+        variant='rectangular'
+        width={700}
+        height={400}
+      />
+      <Skeleton
+        sx={{ bgcolor: 'grey.100' }}
+        variant='rectangular'
+        width={700}
+        height={180}
+      />
+    </>
+  )
+}
+const ArticlesSkeleton = () => {
+  return (
+    <Stack spacing={1}>
+      {Array(2)
+        .fill(1)
+        .map((_, id) => (
+          <ArticleSkeleton key={id} />
+        ))}
+    </Stack>
+  )
+}
+export default ArticlesSkeleton


### PR DESCRIPTION
Для реализации визуала скелетонов статей на страницах решил пробрасывать функцию рендер в Outlet, для удобства добавил хук use-app-outlet
---- src/app/layout/layout.tsx
------ src/shared/hooks/use-app-outlet.ts